### PR TITLE
Require python-requests instead of python2-requests

### DIFF
--- a/python-requests-unixsocket.spec
+++ b/python-requests-unixsocket.spec
@@ -29,7 +29,7 @@ requests_unixsocket.Session() Access /path/to/page from /tmp/profilesvc.sock
 Summary:        %{summary}
 %{?python_provide:%python_provide python2-%{pypi_name}}
 
-Requires:       python2-requests >= 1.1
+Requires:       python-requests >= 1.1
 Requires:       python-urllib3 >= 1.8
 %description -n python2-%{pypi_name}
 requests-unixsocket Use requests < to talk HTTP via a UNIX domain


### PR DESCRIPTION
In order for this package to play nicely with the other requirements in `chroma-manager` and not result in file conflicts, we should require `python-requests`. The other option is to change all the chroma-manager requirements to `python2-requests` which will also work.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>